### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   , "homepage"        : "https://github.com/qiao/difflib.js"
   , "keywords"        : ["diff"]
   , "author"          : "Xueqiao Xu <xueqiaoxu@gmail.com>"
+  , "license"          : "Python-2.0"
   , "main"            : "./index.js"
   , "dependencies"    : {
       "heap"            : ">= 0.2.0"


### PR DESCRIPTION
This allows `yarn licenses` to properly generate attribution