### PR TITLE
change license to valid spdx id

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     , "url"           : "git://github.com/qiao/difflib.js.git"
   }
   , "licenses"        : [{
-      "type"          :  "PSF"
+      "type"          :  "PSF-2.0"
     , "url"           : "http://docs.python.org/license.html"
   }]
 }


### PR DESCRIPTION
Fixes the license string in the package.json to make it SPDX compatible.